### PR TITLE
Use HTTPS endpoint of the Congress API

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1,7 +1,7 @@
 /* ========================================================= ***/
 /** ================== INCLUDE NEEDED MODULES =============== **/
 /*** ========================================================= */
-var http = require("http");
+var https = require("https");
 
 
 /* ========================================================= ***/
@@ -24,7 +24,7 @@ var order = function(field, dir){
     if(arguments.length<0){
         throw Error("MUST SUPPLY AT LEAST ONE ARGUMENT");
     }
-    
+
     if(typeof field === "string"){
 
         if(typeof dir == "undefined"){
@@ -42,7 +42,7 @@ var order = function(field, dir){
     else {
         for(var i=0; i<arguments.length; i++){
 
-            var arg = arguments[i];     
+            var arg = arguments[i];
 
             var field = "";
             var direction = "";
@@ -125,7 +125,7 @@ var filter = function(field, value, operator){
     else{
         this.queryObj[field] = value;
     }
-	
+
 	return this;
 }
 
@@ -143,7 +143,7 @@ var next = function(success, failure){
 
     this.queryObj.page++;
 
-    this.call(success, failure); 
+    this.call(success, failure);
 }
 
 //CALL OUT TO THE API
@@ -184,8 +184,8 @@ var call = function(callback, fail){
 
     var endpoint = this.getEndpoint(this.queryObj);
 
-    
-	http.get(endpoint, function(res){
+
+	https.get(endpoint, function(res){
 		var data = "";
 		res.on("data", function(chunk){
 			data+=chunk;
@@ -230,14 +230,14 @@ var setKey = function(key){
 /** ==================== BASIC OBJECT DATA ================== **/
 /*** ========================================================= */
 
-var basepoint = "http://congress.api.sunlightfoundation.com/";
+var basepoint = "https://congress.api.sunlightfoundation.com/";
 module.exports = {
 
     //BASE DATA
 	apikey : undefined,
 	collection: "",
 	query: "",
-    queryObj: {}, //used to stage 
+    queryObj: {}, //used to stage
 
     //CORE FUNCTIONS
 	call: call,


### PR DESCRIPTION
This updates the library to use the encrypted endpoint of the Congress API, which we recommend as a default.
